### PR TITLE
fix(RLN) check collision

### DIFF
--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -32,7 +32,7 @@ async function checkRLNCollision(roomId: string, message: MessageI): Promise<Col
         if (!message.proof) {
           throw new Error('Proof not provided');
         }
-        if (!oldMessage) {
+        if (!oldMessage || !oldMessage?.epochs[0]?.messages) {
           res({ collision: false } as CollisionCheckResult);
         } else {
           const oldMessageProof = JSON.parse(


### PR DESCRIPTION
If the epoch or its messages didn't exist already, it was throwing an error, so we made a check for that