### PR TITLE
Added Rate Commitment hasher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
         "discreetly-claimcodes": "^1.1.5",
-        "discreetly-interfaces": "^0.1.34",
+        "discreetly-interfaces": "^0.1.35",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-basic-auth": "^1.2.1",
@@ -3469,9 +3469,9 @@
       "integrity": "sha512-pQueoGtBJk/FrTfGzepjqYfTLaymS+4t11byI4OcfjWQOagRsD7dtavGcowTVQ7Ib/vjKna5T+71WcgWZaAWuA=="
     },
     "node_modules/discreetly-interfaces": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/discreetly-interfaces/-/discreetly-interfaces-0.1.34.tgz",
-      "integrity": "sha512-7purPOWOowVH44ebdweBdZ4z2RsBQy5/H7xi6PdsHkaw1xwg8u3Ev2US5EdavP1igZ+SzebJdK8jT0ZTjzX8Kg==",
+      "version": "0.1.35",
+      "resolved": "https://registry.npmjs.org/discreetly-interfaces/-/discreetly-interfaces-0.1.35.tgz",
+      "integrity": "sha512-483vYSdwQ3+jPcHJoP3VEeFpfwGNgfFqjIKy/W1sSFZIAzyztTj534jeF9TwXAJqrP5I/3UbEm596NrCuyH3iw==",
       "dependencies": {
         "poseidon-lite": "^0.2.0",
         "rlnjs": "^3.1.4"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "discreetly-claimcodes": "^1.1.5",
-    "discreetly-interfaces": "^0.1.34",
+    "discreetly-interfaces": "^0.1.35",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-basic-auth": "^1.2.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,23 +11,24 @@ datasource db {
 }
 
 model Rooms {
-  id               String        @id @default(auto()) @map("_id") @db.ObjectId
-  roomId           String        @unique
-  name             String
-  rateLimit        Int           @default(1000) // epoch length in ms
-  banRateLimit     Int           @default(1000000) // starting number of epochs banned for
-  userMessageLimit Int           @default(1) // per epoch
-  membershipType   String        @default("IDENTITY_LIST")
-  identities       String[]      @default([])
-  contractAddress  String? // RLN_CONTRACT as "chainID:0xADDRESS"
-  bandadaAddress   String? // BANDADA as "url:groupID"
-  bandadaGroupId   String? // Bandada Group ID
-  bandadaAPIKey    String? // Bandada API Key
-  epochs           Epoch[]
-  messages         Messages[]
-  claimCodes       ClaimCodes[]  @relation(fields: [claimCodeIds], references: [id])
-  claimCodeIds     String[]      @default([]) @db.ObjectId
-  type             String        @default("PUBLIC")
+  id                  String       @id @default(auto()) @map("_id") @db.ObjectId
+  roomId              String       @unique
+  name                String
+  rateLimit           Int          @default(1000) // epoch length in ms
+  banRateLimit        Int          @default(1000000) // starting number of epochs banned for
+  userMessageLimit    Int          @default(1) // per epoch
+  membershipType      String       @default("IDENTITY_LIST")
+  identities          String[]     @default([])
+  semaphoreIdentities String[]     @default([])
+  contractAddress     String? // RLN_CONTRACT as "chainID:0xADDRESS"
+  bandadaAddress      String? // BANDADA as "url:groupID"
+  bandadaGroupId      String? // Bandada Group ID
+  bandadaAPIKey       String? // Bandada API Key
+  epochs              Epoch[]
+  messages            Messages[]
+  claimCodes          ClaimCodes[] @relation(fields: [claimCodeIds], references: [id])
+  claimCodeIds        String[]     @default([]) @db.ObjectId
+  type                String       @default("PUBLIC")
 }
 
 model ClaimCodes {

--- a/src/crypto/rateCommitmentHasher.ts
+++ b/src/crypto/rateCommitmentHasher.ts
@@ -1,0 +1,7 @@
+import { poseidon2 } from 'poseidon-lite/poseidon2';
+
+function getRateCommitmentHash(identityCommitment: bigint, userMessageLimit: number | bigint) {
+  return poseidon2([identityCommitment, userMessageLimit]);
+}
+
+export default getRateCommitmentHash;

--- a/src/crypto/verifier.ts
+++ b/src/crypto/verifier.ts
@@ -52,8 +52,8 @@ async function verifyProof(msg: MessageI, room: RoomI, epochErrorRange = 5): Pro
   }
 
   // Check that the merkle root is correct
-  if (room.identities && Array.isArray(room.identities)) {
-    const group = new Group(room.roomId, 20, room.identities as bigint[] | undefined);
+  if (room.semaphoreIdentities && Array.isArray(room.semaphoreIdentities)) {
+    const group = new Group(room.roomId, 20, room.semaphoreIdentities as bigint[] | undefined);
     if (group.root !== proof.snarkProof.publicSignals.root) {
       console.warn("GROUP ROOT DOESN'T MATCH PROOF ROOT; USE BANDADA");
     }

--- a/src/crypto/verifier.ts
+++ b/src/crypto/verifier.ts
@@ -52,8 +52,8 @@ async function verifyProof(msg: MessageI, room: RoomI, epochErrorRange = 5): Pro
   }
 
   // Check that the merkle root is correct
-  if (room.semaphoreIdentities && Array.isArray(room.semaphoreIdentities)) {
-    const group = new Group(room.roomId, 20, room.semaphoreIdentities as bigint[] | undefined);
+  if (room.identities && Array.isArray(room.identities)) {
+    const group = new Group(room.roomId, 20, room.identities as bigint[] | undefined);
     if (group.root !== proof.snarkProof.publicSignals.root) {
       console.warn("GROUP ROOT DOESN'T MATCH PROOF ROOT; USE BANDADA");
     }

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -174,6 +174,10 @@ function addIdentityToBandadaRooms(rooms, identityCommitment: string): void {
 
   if (bandadaGroupRooms.length > 0) {
     bandadaGroupRooms.forEach(async (room) => {
+      const rateCommitment = getRateCommitmentHash(
+        BigInt(identityCommitment),
+        BigInt((room.userMessageLimit as number) ?? 1)
+      ).toString()
       if (!room.bandadaAPIKey) {
         console.error('API key is missing for room:', room);
         return;
@@ -189,15 +193,12 @@ function addIdentityToBandadaRooms(rooms, identityCommitment: string): void {
         where: { id: room.id },
         data: {
           identities: {
-            push: getRateCommitmentHash(
-              BigInt(identityCommitment),
-              BigInt((room.userMessageLimit as number) ?? 1)
-            ).toString()
+            push: rateCommitment
           },
           semaphoreIdentities: { push: identityCommitment }
         }
       });
-      const url = `https://${room.bandadaAddress}/groups/${room.bandadaGroupId}/members/${identityCommitment}`;
+      const url = `https://${room.bandadaAddress}/groups/${room.bandadaGroupId}/members/${rateCommitment}`;
       fetch(url, requestOptions)
         .then((res) => {
           if (res.status == 200) {

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -263,7 +263,7 @@ export function removeIdentityFromRoom(
 ): Promise<void | RoomI> {
   const updateSemaphoreIdentities = room.semaphoreIdentities?.map((identity) =>
     identity === idc ? '0n' : identity as string
-  )as string[];
+  )!;
 
   const rateCommitmentsToUpdate = getRateCommitmentHash(BigInt(idc), BigInt(room.userMessageLimit!)).toString()
 

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -6,6 +6,7 @@ import { genId } from 'discreetly-interfaces';
 import type { RoomI } from 'discreetly-interfaces';
 import { serverConfig } from '../config/serverConfig';
 import { genMockUsers, genClaimCodeArray, pp } from '../utils';
+import getRateCommitmentHash from '../crypto/rateCommitmentHasher';
 
 const prisma = new PrismaClient();
 
@@ -124,8 +125,14 @@ export async function updateRoomIdentities(idc: string, roomIds: string[]): Prom
 function addIdentityToIdentityListRooms(rooms, identityCommitment: string): unknown {
   const identityListRooms = rooms
     .filter(
-      (room) =>
-        room.membershipType === 'IDENTITY_LIST' && !room.identities.includes(identityCommitment)
+      (room: RoomI) =>
+        room.membershipType === 'IDENTITY_LIST' &&
+        !room.identities?.includes(
+          getRateCommitmentHash(
+            BigInt(identityCommitment),
+            BigInt(room.userMessageLimit ? room.userMessageLimit : 1)
+          ).toString()
+        )
     )
     .map((room) => room.id as string);
 

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -261,13 +261,23 @@ export function removeIdentityFromRoom(
   idc: string,
   room: RoomI
 ): Promise<void | RoomI> {
-  const updateIdentities = room.identities?.map((identity) =>
-    identity === idc ? '0n' : identity
-  ) as string[];
+  const updateSemaphoreIdentities = room.semaphoreIdentities?.map((identity) =>
+    identity === idc ? '0n' : identity as string
+  )as string[];
+
+  const rateCommitmentsToUpdate = getRateCommitmentHash(BigInt(idc), BigInt(room.userMessageLimit!)).toString()
+
+  const updatedRateCommitments = room.identities?.map((limiter) =>
+    limiter == rateCommitmentsToUpdate ? '0n' : limiter as string
+  )
+
   return prisma.rooms
     .update({
       where: { id: room.id },
-      data: { identities: updateIdentities }
+      data: {
+        identities: updatedRateCommitments,
+        semaphoreIdentities: updateSemaphoreIdentities
+      }
     })
     .then((room) => {
       return room as RoomI;

--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -15,6 +15,7 @@ interface CollisionCheckResult {
   oldMessage?: MessageI;
 }
 
+
 async function checkRLNCollision(
   roomId: string,
   message: MessageI

--- a/src/data/mock.ts
+++ b/src/data/mock.ts
@@ -43,7 +43,7 @@ export default function Mock(io: SocketIOServer) {
       id: faker.number.bigInt().toString(),
       roomId: BigInt('20945462742745557191488383979949684808523754877925170533224967224808050898610'),
       message: picker.pick(),
-      timestamp: Date.now().toString(),
+      timeStamp: Date.now().toString(),
       epoch: Math.floor(Date.now() / 10000)
     };
     console.log('SENDING TEST MESSAGE');

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -44,7 +44,10 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
         .then((room: RoomI) => {
           if (!room) {
             // This is set as a timeout to prevent someone from trying to brute force room ids
-            setTimeout(() => res.status(500).json({ error: 'Internal Server Error' }), 1000);
+            setTimeout(
+              () => res.status(500).json({ error: 'Internal Server Error' }),
+              1000
+            );
           } else {
             const {
               roomId,
@@ -52,7 +55,7 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
               rateLimit,
               userMessageLimit,
               membershipType,
-              semaphoreIdentities,
+              identities,
               contractAddress,
               bandadaAddress,
               bandadaGroupId,
@@ -73,7 +76,7 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
               roomResult.bandadaGroupId = bandadaGroupId;
             }
             if (membershipType === 'IDENTITY_LIST') {
-              roomResult.semaphoreIdentities = semaphoreIdentities as string[];
+              roomResult.identities = identities
             }
             if (type === 'CONTRACT') {
               roomResult.contractAddress = contractAddress;
@@ -89,7 +92,11 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
     ['/rooms/:idc', '/api/rooms/:idc'],
     asyncHandler(async (req: Request, res: Response) => {
       try {
-        pp(String('Express: fetching rooms by identityCommitment ' + req.params.idc));
+        pp(
+          String(
+            'Express: fetching rooms by identityCommitment ' + req.params.idc
+          )
+        );
         res.status(200).json(await getRoomsByIdentity(req.params.idc));
       } catch (error) {
         console.error(error);
@@ -109,7 +116,9 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
       const parsedBody: JoinData = req.body as JoinData;
 
       if (!parsedBody.code || !parsedBody.idc) {
-        res.status(400).json({ message: '{code: string, idc: string} expected' });
+        res
+          .status(400)
+          .json({ message: '{code: string, idc: string} expected' });
       }
       const { code, idc } = parsedBody;
       console.debug('Invite Code:', code);
@@ -257,7 +266,9 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
     asyncHandler(async (req: Request, res: Response) => {
       const { roomId } = req.params;
       const { message } = req.body as { message: string };
-      pp(String('Express: sending system message: ' + message + ' to ' + roomId));
+      pp(
+        String('Express: sending system message: ' + message + ' to ' + roomId)
+      );
       try {
         await createSystemMessages(message, roomId);
         res.status(200).json({ message: 'Message sent to room ' + roomId });

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -52,7 +52,7 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
               rateLimit,
               userMessageLimit,
               membershipType,
-              identities,
+              semaphoreIdentities,
               contractAddress,
               bandadaAddress,
               bandadaGroupId,
@@ -73,7 +73,7 @@ export function initEndpoints(app: Express, adminAuth: RequestHandler) {
               roomResult.bandadaGroupId = bandadaGroupId;
             }
             if (membershipType === 'IDENTITY_LIST') {
-              roomResult.identities = identities;
+              roomResult.semaphoreIdentities = semaphoreIdentities as string[];
             }
             if (type === 'CONTRACT') {
               roomResult.contractAddress = contractAddress;


### PR DESCRIPTION
Anywhere we are adding/accessing an identity commitment, we need to replace it with the hash of the identityCommitment and the userMessageLimit together.

Here is how to use the hasher I added:
```ts
getRateCommitmentHash(
  BigInt(identityCommitment),
  BigInt(room.userMessageLimit ? room.userMessageLimit : 1)
).toString()
```

We need to add this to `addIdentityToIdentityListRooms` and `addIdentityToBandadaRooms` when users join.

We also need to add this to the `/rooms/:idc` route, where we have to hash the idc with every rooms `userMessageLimit` to see what rooms they are in. (OR we can make another database model to map identity commitments to rooms, this is probably smarter and would prevent someone from trying to DDOS our server just by requesting what rooms they are in, hashing takes a decent bit of CPU when you do it a lot).